### PR TITLE
fix: Box 컴포넌트 상속 안받아지는 오류 해결

### DIFF
--- a/components/Box.tsx
+++ b/components/Box.tsx
@@ -31,8 +31,9 @@ function Box({
       height={height}
       borderRadius={borderRadius}
       backgroundColor={backgroundColor}
+      className={className}
     >
-      Box
+      {children}
     </StyledBox>
   );
 }


### PR DESCRIPTION
## 📘 작업 유형

- 버그 수정

<br/>

## 📑 작업리스트

> 작업한 목록

- children, className을 컴포넌트에 안붙여놔서 상속이랑 children이 안받아지는 오류 수정했습니다!

<br />

## 🚧 특이 사항

> PR을 읽을 때 살펴볼 사항


