### PR TITLE
feat: 24기 지원마감 (PM 제외)

### DIFF
--- a/components/recruit/RecruitField/RecruitFieldExplain.tsx
+++ b/components/recruit/RecruitField/RecruitFieldExplain.tsx
@@ -1,6 +1,6 @@
 import { Box, Button } from 'components/common';
 import Breakpoints from 'constants/breakpoints';
-import { IS_RECRUITING } from 'database/recruit';
+import { IS_RECRUITING, IS_RECRUIT_CLOSED_EXCEPT_PM } from 'database/recruit';
 import DOMPurify from 'isomorphic-dompurify';
 import { ReactElement } from 'react';
 import styled from 'styled-components';
@@ -27,6 +27,8 @@ function RecruitFieldExplain({
   developField,
 }: RecruitFieldExplainProps): ReactElement {
   const { content1, content2, content3 } = explainContents;
+
+  const isPM = fieldName === 'PM';
 
   return (
     <RecruitFieldWrapper>
@@ -76,10 +78,14 @@ function RecruitFieldExplain({
           fontColor="white"
           buttonColor="grey_850"
           borderColor="lightGrey"
-          disabled={!IS_RECRUITING}
+          disabled={!IS_RECRUITING || (IS_RECRUIT_CLOSED_EXCEPT_PM && !isPM)}
         >
           {isDeveloper ? developField : fieldName}{' '}
-          {IS_RECRUITING ? '지원하기' : '지원마감'}
+          {IS_RECRUITING && !IS_RECRUIT_CLOSED_EXCEPT_PM
+            ? '지원하기'
+            : IS_RECRUIT_CLOSED_EXCEPT_PM && isPM
+            ? '지원하기'
+            : '지원마감'}
         </ApplyButton>
       </ButtonBlock>
     </RecruitFieldWrapper>

--- a/database/recruit.ts
+++ b/database/recruit.ts
@@ -11,6 +11,11 @@ import Yapp from 'constants/yapp';
 /* 현재 모집중이면 true 아니면 false */
 export const IS_RECRUITING = true;
 
+// TODO : remove (= PM 직군만 연장하므로 다른 직군은 지원버튼 비활성화하기 위해 마감일 생성)
+const recruitCloseDateExceptPM = new Date(2024, 3, 14, 0, 0, 0);
+const now = new Date();
+export const IS_RECRUIT_CLOSED_EXCEPT_PM = now > recruitCloseDateExceptPM;
+
 /** Banner  */
 export const RECRUIT_BANNER = {
   title: '지금은 모집기간이 아닙니다',


### PR DESCRIPTION
## 📘 작업 유형

- 신규 기능 추가

<br/>

## 📑 작업리스트

- 24기 지원마감 (PM 직군 제외 = 과제 전형 추가로 PM 직군만 4/16 까지 지원서 받음)
- 서류 마감 4/14(일) 자정 기준으로 이후 시간이면 `지원하기 버튼` -> `지원마감 버튼` 으로 변경되도록 처리
     
