### PR TITLE
[26기 / HOTFIX] 리쿠르팅 전 배너 텍스트 굵기 변경 

### DIFF
--- a/components/home/IntroSection/Banner26th.tsx
+++ b/components/home/IntroSection/Banner26th.tsx
@@ -120,7 +120,7 @@ const BannerTitleBox = styled.div`
     margin: 0;
     text-align: center;
     font-size: 6.8rem;
-    font-weight: 700;
+    font-weight: 800;
     line-height: 125%;
     letter-spacing: -0.07rem;
     color: ${({ theme }) => theme.palette.black};
@@ -142,7 +142,6 @@ const BannerTitleBox = styled.div`
 `;
 const BannerTitleSpan = styled.span`
   color: ${({ theme }) => theme.palette.blue_100};
-  font-weight: 800;
 `;
 const BannerRecruitDateBox = styled.div`
   color: ${({ theme }) => theme.palette.grey_700};

--- a/components/home/IntroSection/Banner26th.tsx
+++ b/components/home/IntroSection/Banner26th.tsx
@@ -142,7 +142,7 @@ const BannerTitleBox = styled.div`
 `;
 const BannerTitleSpan = styled.span`
   color: ${({ theme }) => theme.palette.blue_100};
-  font-weight: 600;
+  font-weight: 800;
 `;
 const BannerRecruitDateBox = styled.div`
   color: ${({ theme }) => theme.palette.grey_700};


### PR DESCRIPTION
## 📘 작업 유형
- 버그 수정

<br/>

## 📑 작업리스트

-  "26기의 주인공이 되어주세요"  font-weight 값을 700 -> 800으로 수정했습니다
